### PR TITLE
Authorization expects a raw URI accoding to the spec.

### DIFF
--- a/src/nksip_auth.erl
+++ b/src/nksip_auth.erl
@@ -302,7 +302,7 @@ make_auth_request(AuthHeaderData, UserOpts) ->
                 <<"HA1!", HA1/binary>> -> ok; %_Pass = <<"hash">>;
                 _ -> <<"HA1!", HA1/binary>> = make_ha1(User, Pass, Realm)
             end,
-            Uri = nksip_unparse:uri(nksip_lib:get_value(ruri, UserOpts)),
+            Uri = nksip_unparse:ruri(nksip_lib:get_value(ruri, UserOpts)),
             Method1 = case nksip_lib:get_value(method, UserOpts) of
                 'ACK' -> 'INVITE';
                 Method -> Method


### PR DESCRIPTION
There's an issue with the way the authorization response is generated which prevents us from authenticating against certain proxies.

According to RFC 3261, Section 22.4, the URI to be used in the response should follow the production:

URI  =  SIP-URI / SIPS-URI

And this means a raw URI is expected, rather than the delimited variant that is used currently. 