### PR TITLE
Keep options for UAC Auto Auth

### DIFF
--- a/plugins/src/nksip_uac_auto_auth.erl
+++ b/plugins/src/nksip_uac_auto_auth.erl
@@ -141,7 +141,7 @@ check_auth(Req, Resp, UAC, Call) ->
             end,
             case 
                 Passes/=[] andalso Iters < Max andalso 
-                nksip_auth:make_request(Req, Resp, [{passes, Passes}]) 
+                nksip_auth:make_request(Req, Resp, [{passes, Passes}|Opts]) 
             of
                 {ok, Req1} ->
                     {ok, nksip_call_uac:resend(Req1, UAC, Call)};


### PR DESCRIPTION
NkSIP UAC Auto Authentication Plugin does not use original options for request. Fix this.