### PR TITLE
Remove lager runtime dependency

### DIFF
--- a/doc/reference/callback_functions.md
+++ b/doc/reference/callback_functions.md
@@ -505,7 +505,7 @@ handle_call(Msg::term(), From::from(), State::term()) ->
       when State :: term(), Timeout :: infinity | non_neg_integer(), Reason :: term().
 
 handle_call(Msg, _From, State) ->
-    lager:warning("Unexpected handle_call in ~p: ~p", [Msg, ?MODULE]),
+    error_logger:warning_msg("Unexpected handle_call in ~p: ~p", [Msg, ?MODULE]),
     {noreply, State}.
 ```
 
@@ -520,7 +520,7 @@ handle_cast(Msg::term(), State::term()) ->
       when State :: term(), Timeout :: infinity | non_neg_integer(), Reason :: term().
 
 handle_cast(Msg, State) ->
-    lager:warning("Unexpected handle_cast in ~p: ~p", [Msg, ?MODULE]),
+    error_logger:warning_msg("Unexpected handle_cast in ~p: ~p", [Msg, ?MODULE]),
     {noreply, State}.
 ```
 

--- a/doc/reference/configuration.md
+++ b/doc/reference/configuration.md
@@ -63,7 +63,7 @@ route|`user_uri()`|[]|Route (outbound proxy) to use. Generates one or more `Rout
 local_host|auto&#124;`string()`&#124;`binary()`&#124;|auto|Default host or IP to use in headers like _Via_, _Contact_ and _Record-Route_. If set to `auto` NkSIP will use the IP of the transport selected in every case. If that transport is listening on all addresses NkSIP will try to find the best IP using the first valid IP among the network interfaces `ethX` and `enX`, or localhost if none is found
 local_host6|auto&#124;`string()`&#124;`binary()`|auto|Default host or IP to use in headers like _Via_, _Contact_ and _Record-Route_ for IPv6 transports. See `local_host` option.
 no_100|||If present, forbids the generation of automatic `100-type` responses for INVITE requests
-log_level|`debug`&#124;`info`&#124;`notice`&#124;`warning`&#124;`error`|`notice`|Current log level (the [global log level](../reference/log.md) should also be adjusted)
+log_level|`debug`&#124;`info`&#124;`notice`&#124;`warning`&#124;`error`|`notice`|Current log level
 
 
 ## Reconfiguration

--- a/doc/reference/log.md
+++ b/doc/reference/log.md
@@ -1,22 +1,7 @@
 # Logging Options
 
-NkSIP uses [Lager](https://github.com/basho/lager) for logging, supporting multiple log levels, log rotation, etc. The following `Lager` levels are used:
+Although [Lager](https://github.com/basho/lager) is specified as dependency, NkSIP only uses the standard `error_logger` for its internal logging. This means that NkSIP does not enforce a certain logging framework. However, `lager` is used for all `samples` as well as the unit tests.
 
-Level|Typical use
----|---
-`debug`|Maximum level of information. Do not use it in production
-`info`|Detailed information. Not recommended in production
-`notice`|Important information. Recommended in production
-`warning`|Actions you should take into account
-`error`|Important internal errors
-`critical`|Not used currently
-`alert`|Not used currently
-`emergency`|Not used currently
-
-You can configure Lager using its erlang environment variables, or using an erlang start up configuration file (usually called `app.config`). See the `samples` directory for an example of use.
-
-Lager supports several backends, typically console and disk. You can change the current _log level_ with `lager:set_loglevel/2,3` (for example `lager:set_loglevel(lager_console_backend, debug)` and `lager:set_loglevel(lager_file_backend, "console.log", debug)`).
-
-In order for a SipApp to change its log level, not only the global log level must be changed, but also the [application configuration](configuration.md), using the `log_level` option. SipApp config options can be changed on the fly.
+NkSIP allows adjusting a log level per `SipApp` (also at runtime) using the `log_level` option described in the [configuration](configuration.md) section.
 
 To get SIP message tracing, activate the [nksip_trace](../plugins/trace.md) plugin.

--- a/include/nksip.hrl
+++ b/include/nksip.hrl
@@ -32,9 +32,9 @@
     DO_LOG(Level, App, CallId, Text, Opts),
     case CallId of
         <<>> ->
-            lager:Level([{app, App}], "~p "++Text, [App|Opts]);
+            error_logger:Level("~p "++Text, [App|Opts]);
         _ -> 
-            lager:Level([{app, App}, {call_id, CallId}], "~p (~s) "++Text, [App, CallId|Opts])
+            error_logger:Level("~p (~s) "++Text, [App, CallId|Opts])
     end).
 
 -define(DO_DEBUG(AppId, CallId, Level, Text, List),
@@ -47,45 +47,38 @@
 -define(debug(AppId, CallId, Text, List), 
     ?DO_DEBUG(AppId, CallId, debug, Text, List),
     case AppId:config_log_level() >= 8 of
-        true -> ?DO_LOG(debug, AppId:name(), CallId, Text, List);
+        true -> ?DO_LOG(info_msg, AppId:name(), CallId, Text, List);
         false -> ok
     end).
 
 -define(info(AppId, CallId, Text, List), 
     ?DO_DEBUG(AppId, CallId, info, Text, List),
     case AppId:config_log_level() >= 7 of
-        true -> ?DO_LOG(info, AppId:name(), CallId, Text, List);
+        true -> ?DO_LOG(info_msg, AppId:name(), CallId, Text, List);
         false -> ok
     end).
 
 -define(notice(AppId, CallId, Text, List), 
     ?DO_DEBUG(AppId, CallId, notice, Text, List),
     case AppId:config_log_level() >= 6 of
-        true -> ?DO_LOG(notice, AppId:name(), CallId, Text, List);
+        true -> ?DO_LOG(info_msg, AppId:name(), CallId, Text, List);
         false -> ok
     end).
 
 -define(warning(AppId, CallId, Text, List), 
     ?DO_DEBUG(AppId, CallId, warning, Text, List),
     case AppId:config_log_level() >= 5 of
-        true -> ?DO_LOG(warning, AppId:name(), CallId, Text, List);
+        true -> ?DO_LOG(warning_msg, AppId:name(), CallId, Text, List);
         false -> ok
     end).
 
 -define(error(AppId, CallId, Text, List), 
     ?DO_DEBUG(AppId, CallId, error, Text, List),
     case AppId:config_log_level() >= 4 of
-        true -> ?DO_LOG(error, AppId:name(), CallId, Text, List);
+        true -> ?DO_LOG(error_msg, AppId:name(), CallId, Text, List);
         false -> ok
     end).
 
-
--define(N(T), lager:notice(T)).
--define(N(T,P), lager:notice(T,P)).
--define(W(T), lager:warning(T)).
--define(W(T,P), lager:warning(T,P)).
--define(E(T), lager:error(T)).
--define(E(T,P), lager:error(T,P)).
 
 -include_lib("kernel/include/inet_sctp.hrl").
 
@@ -326,7 +319,7 @@
 -endif.
 
 -ifndef(I).
--define(I(S,P), lager:info(S++"\n", P)).
+-define(I(S,P), error_logger:info_msg(S++"\n", P)).
 -define(I(S), ?I(S, [])).
 -endif.
 

--- a/include/nksip_call.hrl
+++ b/include/nksip_call.hrl
@@ -38,28 +38,28 @@
 -define(call_debug(Text, List),
     ?DO_DEBUG(debug, Text, List),
     case erlang:get(nksip_log_level)>=8 of
-        true -> ?DO_CALL_LOG(debug, Text, List);
+        true -> ?DO_CALL_LOG(info_msg, Text, List);
         false -> ok
     end).
 
 -define(call_info(Text, List),
     ?DO_DEBUG(info, Text, List),
     case erlang:get(nksip_log_level)>=7 of
-        true -> ?DO_CALL_LOG(info, Text, List);
+        true -> ?DO_CALL_LOG(info_msg, Text, List);
         false -> ok
     end).
 
 -define(call_notice(Text, List),
     ?DO_DEBUG(notice, Text, List),
     case erlang:get(nksip_log_level)>=6 of
-        true -> ?DO_CALL_LOG(notice, Text, List);
+        true -> ?DO_CALL_LOG(info_msg, Text, List);
         false -> ok
     end).
 
 -define(call_warning(Text, List),
     ?DO_DEBUG(warning, Text, List),
     case erlang:get(nksip_log_level)>=5 of
-        true -> ?DO_CALL_LOG(warning, Text, List);
+        true -> ?DO_CALL_LOG(warning_msg, Text, List);
         false -> 
             ok
     end).
@@ -67,7 +67,7 @@
 -define(call_error(Text, List),
     ?DO_DEBUG(error, Text, List),
     case erlang:get(nksip_log_level)>=4 of
-        true -> ?DO_CALL_LOG(error, Text, List);
+        true -> ?DO_CALL_LOG(error_msg, Text, List);
         false -> ok
     end).
 

--- a/plugins/src/nksip_debug_srv.erl
+++ b/plugins/src/nksip_debug_srv.erl
@@ -53,7 +53,8 @@ init([]) ->
     gen_server_call(#state{}).
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -62,7 +63,8 @@ handle_call(Msg, _From, State) ->
     gen_server_cast(#state{}).
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -71,7 +73,8 @@ handle_cast(Msg, State) ->
     gen_server_info(#state{}).
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/plugins/src/nksip_stats_srv.erl
+++ b/plugins/src/nksip_stats_srv.erl
@@ -68,7 +68,8 @@ handle_call(get_uas_avg, _From, #state{last_uas=LastUas}=State) ->
     {reply, LastUas, State, timeout(State)};
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State, timeout(State)}.
 
 
@@ -81,7 +82,8 @@ handle_cast({response_time, Time}, #state{avg_uas_values=Values}=State) ->
     {noreply, State1, timeout(State1)};
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State, timeout(State)}.
 
 
@@ -96,7 +98,8 @@ handle_info(timeout, #state{avg_uas_values=Values, period=Period}=State) ->
     {noreply, State1, 1000*Period};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, State, timeout(State)}.
 
 

--- a/priv/app.config
+++ b/priv/app.config
@@ -8,7 +8,6 @@
             {lager_file_backend, [{file, "log/error.log"}, {level, error}]},
             {lager_file_backend, [{file, "log/console.log"}, {level, info}]}
         ]},
-        {error_logger_redirect, false},
         {crash_log, "log/crash.log"},
         {colored, true},
         {colors, [

--- a/priv/vm.args
+++ b/priv/vm.args
@@ -28,6 +28,7 @@
 -env ERL_CRASH_DUMP .
 
 # Start apps
+-s lager
 -s nksip_app
 
 

--- a/samples/nksip_loadtest/priv/app.config
+++ b/samples/nksip_loadtest/priv/app.config
@@ -17,7 +17,6 @@
                 {level, info}
             ]}
         ]},
-        {error_logger_redirect, false},
         {colors, [
             {debug,     "\e[0;38m" },
             {info,      "\e[0;32m" },

--- a/samples/nksip_loadtest/priv/vm.args
+++ b/samples/nksip_loadtest/priv/vm.args
@@ -27,6 +27,7 @@
 -env ERL_CRASH_DUMP .
 
 # Start apps
+-s lager
 -s nksip_app
 
 

--- a/samples/nksip_loadtest/src/nksip_loadtest.app.src
+++ b/samples/nksip_loadtest/src/nksip_loadtest.app.src
@@ -3,6 +3,6 @@
     {vsn, "0.4.0"},
     {modules, []},
     {registered, []},
-    {applications, [kernel, stdlib, nksip]},
+    {applications, [kernel, stdlib, lager, nksip]},
     {env, []}
 ]}.

--- a/samples/nksip_pbx/priv/vm.args
+++ b/samples/nksip_pbx/priv/vm.args
@@ -27,6 +27,7 @@
 -env ERL_CRASH_DUMP .
 
 # Start apps
+-s lager
 -s nksip_app
 
 

--- a/samples/nksip_pbx/src/nksip_pbx.app.src
+++ b/samples/nksip_pbx/src/nksip_pbx.app.src
@@ -3,6 +3,6 @@
   {vsn, "0.2.0"},
   {modules, []},
   {registered, []},
-  {applications, [kernel, stdlib, nksip]},
+  {applications, [kernel, stdlib, lager, nksip]},
   {env, []}
 ]}.

--- a/samples/nksip_tutorial/priv/vm.args
+++ b/samples/nksip_tutorial/priv/vm.args
@@ -27,6 +27,7 @@
 -env ERL_CRASH_DUMP .
 
 # Start apps
+-s lager
 -s nksip_app
 
 

--- a/samples/nksip_tutorial/src/nksip_tutorial.app.src
+++ b/samples/nksip_tutorial/src/nksip_tutorial.app.src
@@ -3,6 +3,6 @@
   {vsn, "0.4.0"},
   {modules, []},
   {registered, []},
-  {applications, [kernel, stdlib, nksip]},
+  {applications, [kernel, stdlib, lager, nksip]},
   {env, []}
 ]}.

--- a/src/nksip.app.src
+++ b/src/nksip.app.src
@@ -10,7 +10,6 @@
         crypto,
         sasl,
         ssl,
-        lager,
         ranch,
         cowlib,
         cowboy

--- a/src/nksip_app.erl
+++ b/src/nksip_app.erl
@@ -62,8 +62,9 @@ start(_Type, _Args) ->
     MainIp = nksip_config:get(main_ip),
     MainIp6 = nksip_config:get(main_ip6),
     {ok, Vsn} = application:get_key(nksip, vsn),
-    lager:notice("NkSIP v~s has started. Main IP is ~s (~s)", 
-                    [Vsn, nksip_lib:to_host(MainIp), nksip_lib:to_host(MainIp6)]),
+    error_logger:info_msg(
+      "NkSIP v~s has started. Main IP is ~s (~s)", 
+      [Vsn, nksip_lib:to_host(MainIp), nksip_lib:to_host(MainIp6)]),
     {ok, Pid}.
 
 

--- a/src/nksip_call_event.erl
+++ b/src/nksip_call_event.erl
@@ -43,8 +43,9 @@
 uac_pre_request(#sipmsg{class={req, 'NOTIFY'}}=Req, Dialog, _Call) ->
     case nksip_subscription_lib:find(Req, Dialog) of
         not_found ->  
-            % lager:warning("PRE REQ: ~p, ~p", 
-            %         [nksip_subscription_lib:make_id(Req), Dialog#dialog.subscriptions]),
+            % error_logger:warning_msg(
+            %   "PRE REQ: ~p, ~p", 
+            %   [nksip_subscription_lib:make_id(Req), Dialog#dialog.subscriptions]),
             {error, no_transaction};
         #subscription{class=uas} -> 
             ok;

--- a/src/nksip_call_proxy.erl
+++ b/src/nksip_call_proxy.erl
@@ -45,7 +45,7 @@ route(UriList, ProxyOpts, UAS, Call) ->
             [[]] -> throw({reply, temporarily_unavailable});
             UriSet0 -> UriSet0
         end,
-        % lager:warning("URISET: ~p", [UriList]),
+        % error_logger:warning_msg("URISET: ~p", [UriList]),
         #trans{method=Method} = UAS,
         case AppId:nkcb_route(UriSet, ProxyOpts, UAS, Call) of
             {continue, [UriSet1, ProxyOpts1, UAS1, Call1]} ->

--- a/src/nksip_call_srv.erl
+++ b/src/nksip_call_srv.erl
@@ -118,7 +118,8 @@ handle_call(get_data, _From, Call) ->
     {reply, {Trans, Forks, Dialogs}, Call};
  
  handle_call(Msg, _From, Call) ->
-    lager:error("Module ~p received unexpected sync event: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected sync event: ~p",
+                           [?MODULE, Msg]),
     {noreply, Call}.
 
 
@@ -137,7 +138,8 @@ handle_cast(stop, Call) ->
     {stop, normal, Call};
 
 handle_cast(Msg, Call) ->
-    lager:error("Module ~p received unexpected event: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected event: ~p",
+                           [?MODULE, Msg]),
     {noreply, Call}.
 
 
@@ -158,7 +160,8 @@ handle_info({timeout, Ref, Type}, Call) ->
 %     next(Call);
 
 handle_info(Info, Call) ->
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, Call}.
 
 

--- a/src/nksip_call_uas_process.erl
+++ b/src/nksip_call_uas_process.erl
@@ -134,7 +134,7 @@ check_missing_dialog(Method, _Req, UAS, #call{app_id=AppId}=Call) ->
     nksip_call:call().
 
 dialog(Method, Req, UAS, Call) ->
-    % lager:error("DIALOG: ~p\n~p\n~p\n~p", [Method, Req, UAS, Call]),
+    % error_logger:error_msg("DIALOG: ~p\n~p\n~p\n~p", [Method, Req, UAS, Call]),
     #sipmsg{to={_, ToTag}} = Req,
     #trans{id=Id, opts=Opts, stateless=Stateless} = UAS,
     case Stateless orelse ToTag == <<>> of
@@ -197,7 +197,8 @@ call_user_sip_method(UAS, Call) ->
 %     nksip_call:call().
 
 % dialog(Method, Req, UAS, Call) ->
-%     % lager:error("DIALOG: ~p\n~p\n~p\n~p", [Method, Req, UAS, Call]),
+%     % error_logger:error_msg("DIALOG: ~p\n~p\n~p\n~p",
+%                              [Method, Req, UAS, Call]),
 %     #sipmsg{to={_, ToTag}} = Req,
 %     #trans{id=Id, opts=Opts, stateless=Stateless} = UAS,
 %     #call{app_id=AppId} = Call,

--- a/src/nksip_config.erl
+++ b/src/nksip_config.erl
@@ -149,7 +149,7 @@ make_cache() ->
             make_cache(CacheConfig),
             ok;
         {error, Error} ->
-            lager:error("Config error: ~p", [Error]),
+            error_logger:error_msg("Config error: ~p", [Error]),
             error(config_error)
     end.
 
@@ -191,7 +191,8 @@ init([]) ->
     gen_server_call(#state{}).
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 %% @private
@@ -199,7 +200,8 @@ handle_call(Msg, _From, State) ->
     gen_server_cast(#state{}).
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -208,7 +210,8 @@ handle_cast(Msg, State) ->
     gen_server_info(#state{}).
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/src/nksip_connection.erl
+++ b/src/nksip_connection.erl
@@ -308,7 +308,8 @@ handle_call(get_refresh, From, State) ->
     do_noreply(State);
 
 handle_call(Msg, _From, State) ->
-    lager:error("Module ~p received unexpected call: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call: ~p",
+                           [?MODULE, Msg]),
     do_noreply(State).
 
 
@@ -367,7 +368,8 @@ handle_cast({stop, Reason}, State) ->
     do_stop(Reason, State);
 
 handle_cast(Msg, State) ->
-    lager:error("Module ~p received unexpected cast: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast: ~p",
+                           [?MODULE, Msg]),
     do_noreply(State).
 
 
@@ -433,7 +435,8 @@ handle_info(timeout, State) ->
     do_stop(process_timeout, State);
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     do_noreply(State).
 
 

--- a/src/nksip_counters.erl
+++ b/src/nksip_counters.erl
@@ -161,7 +161,8 @@ handle_call(stop, _from, State) ->
     {stop, normal, ok, State};
 
 handle_call(Msg, _From, State) ->
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -174,7 +175,8 @@ handle_cast({multi, List}, State) ->
     {noreply, State};
 
 handle_cast(Msg, State) ->
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -192,7 +194,8 @@ handle_info({'DOWN', Ref, process, Pid, _Reason}, State) ->
     {noreply, State};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected cast ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected cast ~p",
+                             [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/src/nksip_dns.erl
+++ b/src/nksip_dns.erl
@@ -282,7 +282,8 @@ init([]) ->
     gen_server_call(#state{}).
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -291,7 +292,8 @@ handle_call(Msg, _From, State) ->
     gen_server_cast(#state{}).
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -307,7 +309,8 @@ handle_info({timeout, _, check_ttl}, #state{ttl=TTL}=State) ->
     {noreply, State};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/src/nksip_lib.erl
+++ b/src/nksip_lib.erl
@@ -799,7 +799,7 @@ cancel_timer(_) ->
 msg(Msg, Vars) ->
     case catch list_to_binary(io_lib:format(Msg, Vars)) of
         {'EXIT', _} -> 
-            lager:warning("MSG PARSE ERROR: ~p, ~p", [Msg, Vars]),
+            error_logger:warning_msg("MSG PARSE ERROR: ~p, ~p", [Msg, Vars]),
             <<"Msg parser error">>;
         Result -> 
             Result

--- a/src/nksip_parse_sipmsg.erl
+++ b/src/nksip_parse_sipmsg.erl
@@ -49,7 +49,7 @@ parse(Bin) ->
         {ok, Class, Headers, Rest2}
     catch
         throw:{line, _Line} -> 
-            % lager:error("LINE: ~p", [_Line]),
+            % error_logger:error_msg("LINE: ~p", [_Line]),
             error
     end.
 

--- a/src/nksip_parse_tokens.erl
+++ b/src/nksip_parse_tokens.erl
@@ -56,7 +56,8 @@ tokens(_) ->
 tokens(String, Acc) ->
     case name(strip(String), []) of
         {error, _Type, _Line} -> 
-            % lager:debug("Error parsing token ~s: ~p (~p)", [String, _Type, _Line]),
+            % error_logger:info_msg("Error parsing token ~s: ~p (~p)",
+            %                       [String, _Type, _Line]),
             error;
         {Name, Opts, []} when Acc==[]-> 
             [{Name, Opts}];

--- a/src/nksip_parse_uri.erl
+++ b/src/nksip_parse_uri.erl
@@ -60,7 +60,8 @@ uris(String, Acc) ->
         {#uri{}=Uri, []} -> lists:reverse([Uri|Acc]);
         {#uri{}=Uri, Rest} -> uris(Rest, [Uri|Acc]);
         {error, _Type, _Line} -> 
-            % lager:info("Error parsing uri ~p: ~p (~p)", [String, _Type, _Line]),
+            % error_logger:info_msg("Error parsing uri ~p: ~p (~p)",
+            %                       [String, _Type, _Line]),
             error
     end.
 

--- a/src/nksip_parse_via.erl
+++ b/src/nksip_parse_via.erl
@@ -55,7 +55,8 @@ vias(String, Acc) ->
         {#via{}=Via, []} -> lists:reverse([Via|Acc]);
         {#via{}=Via, Rest} -> vias(Rest, [Via|Acc]);
         {error, _Type, _Line} -> 
-            % lager:debug("Error parsing via ~s: ~p (~p)", [String, _Type, _Line]),
+            % error_logger:info_msg("Error parsing via ~s: ~p (~p)",
+            %                       [String, _Type, _Line]),
             error
     end.
 

--- a/src/nksip_proc.erl
+++ b/src/nksip_proc.erl
@@ -312,7 +312,8 @@ handle_call(stop, _From, State) ->
     {stop, normal, State};
 
 handle_call(Msg, _From, State) ->
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -333,7 +334,8 @@ handle_cast({del_all, Pid}, State) ->
     {noreply, State};
 
 handle_cast(Msg, State) ->
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -346,7 +348,8 @@ handle_info({'DOWN', _Ref, process, Pid, _Reason}, State) ->
     {noreply, State};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected cast ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected cast ~p",
+                             [?MODULE, Info]),
     {noreply, State}.
 
 
@@ -529,7 +532,8 @@ start(Type, Link, Name, Module, Args) ->
             receive 
                 {Ref, Result} -> Result
             after 60000 -> 
-                lager:error("Timeout when creating process ~p", [Name]),
+                error_logger:error_msg("Timeout when creating process ~p",
+                                       [Name]),
                 exit(Pid, kill),
                 {error, timeout}
             end;

--- a/src/nksip_router.erl
+++ b/src/nksip_router.erl
@@ -189,7 +189,8 @@ handle_call(pending, _From, #state{pending=Pending}=SD) ->
     {reply, dict:size(Pending), SD};
 
 handle_call(Msg, _From, SD) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, SD}.
 
 
@@ -208,7 +209,8 @@ handle_cast({incoming, SipMsg}, SD) ->
     end;
 
 handle_cast(Msg, SD) ->
-    lager:error("Module ~p received unexpected event: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected event: ~p",
+                           [?MODULE, Msg]),
     {noreply, SD}.
 
 
@@ -224,7 +226,7 @@ handle_info({sync_work_ok, Ref, Pid}, #state{pending=Pending}=SD) ->
             WorkList1 = lists:keydelete(Ref, 1, WorkList),
             dict:store(Pid, {AppId, CallId, WorkList1}, Pending);
         error ->
-            lager:warning("Receiving sync_work_ok for unknown work"),
+            error_logger:warning_msg("Receiving sync_work_ok for unknown work"),
             Pending
     end,
     {noreply, SD#state{pending=Pending1}};
@@ -256,7 +258,8 @@ handle_info({'DOWN', _MRef, process, Pid, _Reason}, SD) ->
     end;
 
 handle_info(Info, SD) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, SD}.
 
 

--- a/src/nksip_sipapp.erl
+++ b/src/nksip_sipapp.erl
@@ -258,7 +258,8 @@ terminate(_Reason, _State) ->
     {stop, Reason::term(), State::term()}.
 
 handle_call(Msg, _From, State) ->
-    lager:warning("Unexpected handle_call in ~p: ~p", [Msg, ?MODULE]),
+    error_logger:warning_msg("Unexpected handle_call in ~p: ~p",
+                             [Msg, ?MODULE]),
     {noreply, State}.
 
 
@@ -270,7 +271,8 @@ handle_call(Msg, _From, State) ->
     {stop, Reason::term(), State::term()}.
 
 handle_cast(Msg, State) ->
-    lager:warning("Unexpected handle_cast in ~p: ~p", [Msg, ?MODULE]),
+    error_logger:warning_msg("Unexpected handle_cast in ~p: ~p",
+                             [Msg, ?MODULE]),
     {noreply, State}.
 
 

--- a/src/nksip_sipapp_srv.erl
+++ b/src/nksip_sipapp_srv.erl
@@ -435,7 +435,8 @@ save_uuid(Path, AppId, UUID) ->
         ok ->
             ok;
         Error ->
-            lager:warning("Could not write file ~s: ~p", [Path, Error]),
+            error_logger:warning_msg("Could not write file ~s: ~p",
+                                     [Path, Error]),
             ok
     end.
 

--- a/src/nksip_store.erl
+++ b/src/nksip_store.erl
@@ -231,7 +231,8 @@ handle_call(stop, _From, State) ->
     {stop, normal, ok, State};
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -240,7 +241,8 @@ handle_call(Msg, _From, State) ->
     gen_server_cast(#state{}).
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -260,7 +262,8 @@ handle_info({timeout, _, timer}, State) ->
     {noreply, State};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/src/nksip_transport_sctp.erl
+++ b/src/nksip_transport_sctp.erl
@@ -144,7 +144,8 @@ handle_call({connect, Ip, Port}, From, State) ->
     {noreply, State#state{pending=[{{Ip, Port}, From}|Pending]}};
 
 handle_call(Msg, _From, State) ->
-    lager:error("Module ~p received unexpected call: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call: ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -161,7 +162,8 @@ handle_cast(stop, State) ->
     {stop, normal, State};
 
 handle_cast(Msg, State) ->
-    lager:error("Module ~p received unexpected cast: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast: ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -217,7 +219,8 @@ handle_info({sctp, Socket, Ip, Port, {Anc, SAC}}, State) ->
     {noreply, State1};
 
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p (~p)", [?MODULE, Info, State]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p (~p)",
+                             [?MODULE, Info, State]),
     {noreply, State}.
 
 

--- a/src/nksip_transport_udp.erl
+++ b/src/nksip_transport_udp.erl
@@ -175,7 +175,8 @@ handle_call(get_port, _From, #state{transport=#transport{listen_port=Port}}=Stat
     {reply, {ok, Port}, State};
 
 handle_call(Msg, _Form, State) -> 
-    lager:error("Module ~p received unexpected call: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call: ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -193,7 +194,8 @@ handle_cast({send_stun, Ip, Port, Pid}, #state{app_id=AppId}=State) ->
     {noreply, do_send_stun(AppId, Ip, Port, {cast, Pid}, State)};
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast: ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast: ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -237,7 +239,8 @@ handle_info({timeout, Ref, stun_retrans}, #state{stuns=Stuns}=State) ->
     {noreply, do_stun_retrans(Stun1, State#state{stuns=Stuns1})};
    
 handle_info(Info, State) -> 
-    lager:warning("Module ~p received unexpected info: ~p", [?MODULE, Info]),
+    error_logger:warning_msg("Module ~p received unexpected info: ~p",
+                             [?MODULE, Info]),
     {noreply, State}.
 
 

--- a/src/nksip_transport_ws.erl
+++ b/src/nksip_transport_ws.erl
@@ -204,7 +204,8 @@ init([AppId, Transp, Dispatch, Opts]) ->
     gen_server_call(#state{}).
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 %% @private
@@ -212,7 +213,8 @@ handle_call(Msg, _From, State) ->
     gen_server_cast(#state{}).
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -224,7 +226,8 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, #state{webserver=MRef}=State
     {noreply, State};
     
 handle_info(Msg, State) -> 
-    lager:warning("Module ~p received unexpected info ~p", [?MODULE, Msg]),
+    error_logger:warning_msg("Module ~p received unexpected info ~p",
+                             [?MODULE, Msg]),
     {noreply, State}.
 
 

--- a/src/nksip_webserver.erl
+++ b/src/nksip_webserver.erl
@@ -207,7 +207,8 @@ handle_call(state, _From, State) ->
     {reply, State, State};
 
 handle_call(Msg, _From, State) -> 
-    lager:error("Module ~p received unexpected call ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected call ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 %% @private
@@ -230,7 +231,8 @@ handle_cast(stop_all, State) ->
     {noreply, State#state{servers=[]}};
 
 handle_cast(Msg, State) -> 
-    lager:error("Module ~p received unexpected cast ~p", [?MODULE, Msg]),
+    error_logger:error_msg("Module ~p received unexpected cast ~p",
+                           [?MODULE, Msg]),
     {noreply, State}.
 
 
@@ -249,7 +251,7 @@ handle_info({'DOWN', MRef, process, _Pid, _Reason}, State) ->
                 false ->
                     {noreply, State};
                 {value, #server_info{ref=Ref}, Servers1} ->
-                    lager:warning("Web server ~p has failed!", [Ref]),
+                    error_logger:warning_msg("Web server ~p has failed!", [Ref]),
                     {noreply, State#state{servers=Servers1}}
             end
     end.

--- a/test/app.config
+++ b/test/app.config
@@ -3,7 +3,7 @@
     ]},
     {lager, [
         {handlers, [{lager_console_backend, warning}]},
-        {error_logger_redirect, false},
+        {error_logger_hwm, undefined},
         {colored, true}
     ]},
     {sasl, [

--- a/test/tests_util.erl
+++ b/test/tests_util.erl
@@ -34,6 +34,7 @@
 -endif.
 
 start_nksip() ->
+    lager:start(),
     nksip_app:start(),
     log().
 


### PR DESCRIPTION
Remove the runtime dependency to the `lager` logging framework and convert all logging statements to use default `error_logger`. However, the `rebar.config` dependency for `lager` is still there and is still used when running tests and samples making their output more readable (utilizing the `error_logger` handler).

Although `lager` is very popular, not everyone uses it to handle logging in their release. Not forcing
others to switch their logging to `lager` would definitely increase the project's acceptance and distribution.
