### PR TITLE
Changed token parsing to support empty header fields

### DIFF
--- a/src/nksip_parse.erl
+++ b/src/nksip_parse.erl
@@ -121,6 +121,7 @@ vias(Term) -> vias([Term]).
 -spec tokens(Term :: binary() | string() | [binary() | string()]) -> 
     [nksip:token()] | error.
 
+tokens([<<>>]) -> [];
 tokens([]) -> [];
 tokens([First|_]=String) when is_integer(First) -> tokens([String]);  
 tokens(List) when is_list(List) -> parse_tokens(List, []);


### PR DESCRIPTION
The SIP RFC 3261 permits empty values for the Supported header field. Parsing such a header currently  fails with

    Error parsing SipMsg: {invalid,<<"Supported">>}

I just added 

    tokens([<<>>]) -> [];

to return an empty list. Is this the correct way? Any suggestions are welcome.